### PR TITLE
feat(log) add a source-trace to the error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 0.x.x Unreleased
+
+ - added a trace to errors to identify to originating yaml/json element that
+   caused the error.
+
 ## 0.1.0
 
 - initial version

--- a/spec/00-common_spec.lua
+++ b/spec/00-common_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local common = require "openapi2kong.common"
 local openapi = require "openapi2kong.openapi"
 

--- a/spec/01-openapis_spec.lua
+++ b/spec/01-openapis_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local openapi = require "openapi2kong.openapi"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,13 +7,13 @@ describe("[openapi]", function()
 
   it("requires a table parameter", function()
     local ok, err = openapi("lalala")
-    assert.equal("a openapi object expects a table, but got string", err)
+    assert.equal("a openapi object expects a table, but got string (origin: openapi)", err)
     assert.falsy(ok)
   end)
 
   it("requires an openapi version", function()
     local ok, err = openapi({})
-    assert.equal("missing openapi version", err)
+    assert.equal("missing openapi version (origin: openapi)", err)
     assert.falsy(ok)
   end)
 
@@ -20,7 +21,7 @@ describe("[openapi]", function()
     local ok, err = openapi({
       openapi = "2.0"
     })
-    assert.equal("unsupported major version: 2. OAS major version v3 supported", err)
+    assert.equal("unsupported major version: 2. OAS major version v3 supported (origin: openapi)", err)
     assert.falsy(ok)
 
     local result, err = openapi({
@@ -60,7 +61,7 @@ describe("[openapi]", function()
       paths = { ["/"] = {} },
       security = "lalala",
     })
-    assert.equal("a openapi object expects a table as security property, but got string", err)
+    assert.equal("a openapi object expects a table as security property, but got string (origin: openapi)", err)
     assert.falsy(ok)
   end)
 
@@ -70,7 +71,7 @@ describe("[openapi]", function()
       servers = { "http://server.com/path" },
       --paths = { ["/"] = {} },
     })
-    assert.equal("missing paths property", err)
+    assert.equal("missing paths property (origin: openapi)", err)
     assert.falsy(ok)
   end)
 
@@ -80,7 +81,7 @@ describe("[openapi]", function()
       servers = { "http://server.com/path" },
       paths = {},
     })
-    assert.equal("paths needs at least 1 path entry", err)
+    assert.equal("paths needs at least 1 path entry (origin: openapi)", err)
     assert.falsy(ok)
   end)
 
@@ -91,7 +92,7 @@ describe("[openapi]", function()
       paths = { ["/"] = {} },
       ["x-kong-unsupported-one"] = { "this should fail" }
     })
-    assert.equal("Not a valid Kong extension: x-kong-unsupported-one", err)
+    assert.equal("Not a valid Kong extension: x-kong-unsupported-one (origin: openapi)", err)
     assert.is_nil(result)
   end)
 
@@ -118,7 +119,7 @@ describe("[openapi]", function()
       },
       paths = { ["/"] = {} },
     })
-    assert.equal("Kong extension 'x-kong-upstream-defaults' cannot be used on type 'server'", err)
+    assert.equal("Kong extension 'x-kong-upstream-defaults' cannot be used on type 'server' (origin: openapi)", err)
     assert.is_nil(result)
   end)
 

--- a/spec/02-servers_spec.lua
+++ b/spec/02-servers_spec.lua
@@ -1,10 +1,11 @@
+_G._TEST = true
 local servers = require "openapi2kong.servers"
 
 describe("[servers]", function()
 
   it("requires a table parameter", function()
     local ok, err = servers("lalala", nil, {})
-    assert.equal("a servers object expects a table, but got string", err)
+    assert.equal("a servers object expects a table, but got string (origin: PARENT:servers)", err)
     assert.falsy(ok)
   end)
 
@@ -50,7 +51,7 @@ describe("[servers]", function()
         url = "http://server2.com/path2",
       },
     }, nil, {})
-    assert.equal("server urls should not differ other than host or port", err)
+    assert.equal("server urls should not differ other than host or port (origin: PARENT:servers)", err)
     assert.is_nil(ok)
   end)
 

--- a/spec/03-server_spec.lua
+++ b/spec/03-server_spec.lua
@@ -1,10 +1,11 @@
+_G._TEST = true
 local server = require "openapi2kong.server"
 
 describe("[server]", function()
 
   it("requires a table parameter", function()
     local ok, err = server(123, nil, {})
-    assert.equal("a server object expects a table, but got number", err)
+    assert.equal("a server object expects a table, but got number (origin: PARENT:server[<bad spec: number>])", err)
     assert.falsy(ok)
   end)
 

--- a/spec/04-paths_spec.lua
+++ b/spec/04-paths_spec.lua
@@ -1,10 +1,11 @@
+_G._TEST = true
 local paths = require "openapi2kong.paths"
 
 describe("[paths]", function()
 
   it("requires a table parameter", function()
     local ok, err = paths("lalala", nil, {})
-    assert.equal("a paths object expects a table, but got string", err)
+    assert.equal("a paths object expects a table, but got string (origin: PARENT:paths)", err)
     assert.falsy(ok)
   end)
 

--- a/spec/05-path_spec.lua
+++ b/spec/05-path_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local path = require "openapi2kong.path"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,7 +7,7 @@ describe("[path]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = path("/", "lalala", nil, {})
-    assert.equal("a path object expects a table as spec, but got string", err)
+    assert.equal("a path object expects a table as spec, but got string (origin: PARENT:path[/])", err)
     assert.falsy(ok)
   end)
 
@@ -16,7 +17,7 @@ describe("[path]", function()
 
     it("requires a string parameter", function()
       local ok, err = path(12, {}, nil, {})
-      assert.equal("a path object expects a string as path, but got number", err)
+      assert.equal("a path object expects a string as path, but got number (origin: PARENT:path[12])", err)
       assert.falsy(ok)
     end)
 

--- a/spec/06-operation_spec.lua
+++ b/spec/06-operation_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local common = require "openapi2kong.common"
 local operation = require "openapi2kong.operation"
 
@@ -7,7 +8,7 @@ describe("[operation]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = operation("get", "lalala", nil, {})
-    assert.equal("a operation object expects a table as spec, but got string", err)
+    assert.equal("a operation object expects a table as spec, but got string (origin: PARENT:operation[get])", err)
     assert.falsy(ok)
   end)
 
@@ -17,7 +18,7 @@ describe("[operation]", function()
 
     it("requires a string parameter", function()
       local ok, err = operation(12, {}, nil, {})
-      assert.equal("a operation object expects a string as method, but got number", err)
+      assert.equal("a operation object expects a string as method, but got number (origin: PARENT:operation[12])", err)
       assert.falsy(ok)
     end)
 
@@ -35,7 +36,7 @@ describe("[operation]", function()
 
     it("fails on bad parameters", function()
       local ok, err = operation("get", { parameters = "" }, nil, {})
-      assert.equal("a parameters object expects a table as spec, but got string", err)
+      assert.equal("a parameters object expects a table as spec, but got string (origin: PARENT:operation[get]:parameters)", err)
       assert.falsy(ok)
     end)
 
@@ -53,7 +54,7 @@ describe("[operation]", function()
 
     it("fails on bad parameters", function()
       local ok, err = operation("get", { requestBody = "" }, nil, {})
-      assert.equal("a requestBody object expects a table as spec, but got string", err)
+      assert.equal("a requestBody object expects a table as spec, but got string (origin: PARENT:operation[get]:requestBody)", err)
       assert.falsy(ok)
     end)
 
@@ -71,7 +72,7 @@ describe("[operation]", function()
 
     it("fails on bad parameters", function()
       local ok, err = operation("get", { security = "" }, nil, {})
-      assert.equal("a operation object expects a table as security property, but got string", err)
+      assert.equal("a operation object expects a table as security property, but got string (origin: PARENT:operation[get])", err)
       assert.falsy(ok)
     end)
 
@@ -117,7 +118,7 @@ describe("[operation]", function()
 
     it("fails on bad parameters", function()
       local ok, err = operation("get", { servers = "" }, nil, {})
-      assert.equal("a servers object expects a table, but got string", err)
+      assert.equal("a servers object expects a table, but got string (origin: PARENT:operation[get]:servers)", err)
       assert.falsy(ok)
     end)
 

--- a/spec/07-parameters_spec.lua
+++ b/spec/07-parameters_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local parameters = require "openapi2kong.parameters"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,7 +7,7 @@ describe("[parameters]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = parameters("lalala", nil, {})
-    assert.equal("a parameters object expects a table as spec, but got string", err)
+    assert.equal("a parameters object expects a table as spec, but got string (origin: PARENT:parameters)", err)
     assert.falsy(ok)
   end)
 
@@ -32,7 +33,7 @@ describe("[parameters]", function()
 
   it("rejects a bad parameter", function()
     local ok, err = parameters({ [1] = 123 }, nil, {})
-    assert.equal("a parameter object expects a table as spec, but got number", err)
+    assert.equal("a parameter object expects a table as spec, but got number (origin: PARENT:parameters:parameter[<bad spec: number>])", err)
     assert.falsy(ok)
   end)
 

--- a/spec/08-parameter_spec.lua
+++ b/spec/08-parameter_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local parameter = require "openapi2kong.parameter"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,7 +7,7 @@ describe("[parameter]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = parameter("lalala", nil, {})
-    assert.equal("a parameter object expects a table as spec, but got string", err)
+    assert.equal("a parameter object expects a table as spec, but got string (origin: PARENT:parameter[<bad spec: string>])", err)
     assert.falsy(ok)
   end)
 
@@ -61,7 +62,7 @@ describe("[parameter]", function()
         name = "param_name",
         schema = {},
       }, nil, {})
-    assert.equal("parameter.in cannot have value 'this is a bad one'", err)
+    assert.equal("parameter.in cannot have value 'this is a bad one' (origin: PARENT:parameter[param_name])", err)
     assert.is_nil(result)
   end)
 
@@ -73,7 +74,7 @@ describe("[parameter]", function()
         name = "param_name",
         schema = {},
       }, nil, {})
-    assert.equal("parameter.required must be true, if parameter.in == 'path'", err)
+    assert.equal("parameter.required must be true, if parameter.in == 'path' (origin: PARENT:parameter[param_name])", err)
     assert.is_nil(result)
   end)
 
@@ -87,7 +88,7 @@ describe("[parameter]", function()
           schema = {},
           content = {},
         }, nil, {})
-      assert.equal("parameter cannot have both schema and content properties", err)
+      assert.equal("parameter cannot have both schema and content properties (origin: PARENT:parameter[param_name])", err)
       assert.is_nil(result)
     end)
 
@@ -99,7 +100,7 @@ describe("[parameter]", function()
           --schema = {},
           --content = {},
         }, nil, {})
-      assert.equal("parameter must have either schema or content property", err)
+      assert.equal("parameter must have either schema or content property (origin: PARENT:parameter[param_name])", err)
       assert.is_nil(result)
     end)
 
@@ -263,7 +264,7 @@ describe("[parameter]", function()
         name = "param_name",
         schema = "should have been a table!",
       }, nil, {})
-    assert.equal("a schema object expects a table as spec, but got string", err)
+    assert.equal("a schema object expects a table as spec, but got string (origin: PARENT:parameter[param_name]:schema)", err)
     assert.is_nil(result)
   end)
 
@@ -287,7 +288,7 @@ describe("[parameter]", function()
         name = "param_name",
         content = { ["application/json"] = "should have been a table!" },
       }, nil, {})
-    assert.equal("a mediaType object expects a table as spec, but got string", err)
+    assert.equal("a mediaType object expects a table as spec, but got string (origin: PARENT:parameter[param_name]:mediaType[application/json])", err)
     assert.is_nil(result)
   end)
 

--- a/spec/09-schema_spec.lua
+++ b/spec/09-schema_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local openapi = require "openapi2kong.openapi"
 local schema = require "openapi2kong.schema"
 local deepcopy = require("pl.tablex").deepcopy
@@ -8,7 +9,7 @@ describe("[schema]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = schema("lalala", nil, {})
-    assert.equal("a schema object expects a table as spec, but got string", err)
+    assert.equal("a schema object expects a table as spec, but got string (origin: PARENT:schema)", err)
     assert.falsy(ok)
   end)
 

--- a/spec/10-mediaType_spec.lua
+++ b/spec/10-mediaType_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local mediaType = require "openapi2kong.mediaType"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,13 +7,13 @@ describe("[mediaType]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = mediaType("application/json", "lalala", nil, {})
-    assert.equal("a mediaType object expects a table as spec, but got string", err)
+    assert.equal("a mediaType object expects a table as spec, but got string (origin: PARENT:mediaType[application/json])", err)
     assert.falsy(ok)
   end)
 
   it("requires a string parameter as mediatype", function()
     local ok, err = mediaType(123, {}, nil, {})
-    assert.equal("a mediaType object expects a string as mediatype, but got number", err)
+    assert.equal("a mediaType object expects a string as mediatype, but got number (origin: PARENT:mediaType[123])", err)
     assert.falsy(ok)
   end)
 
@@ -47,7 +48,7 @@ describe("[mediaType]", function()
           },
         },
       }, nil, {})
-    assert.equal("a schema object expects a table as spec, but got string", err)
+    assert.equal("a schema object expects a table as spec, but got string (origin: PARENT:mediaType[application/json]:schema)", err)
     assert.is_nil(result)
   end)
 
@@ -64,7 +65,7 @@ describe("[mediaType]", function()
         },
         encoding = "lalala",
       }, nil, {})
-    assert.equal("a encodings object expects a table, but got string", err)
+    assert.equal("a encodings object expects a table, but got string (origin: PARENT:mediaType[application/json]:encodings)", err)
     assert.is_nil(result)
   end)
 

--- a/spec/11-encodings_spec.lua
+++ b/spec/11-encodings_spec.lua
@@ -1,10 +1,11 @@
+_G._TEST = true
 local encodings = require "openapi2kong.encodings"
 
 describe("[encodings]", function()
 
   it("requires a table parameter", function()
     local ok, err = encodings("lalala", nil, {})
-    assert.equal("a encodings object expects a table, but got string", err)
+    assert.equal("a encodings object expects a table, but got string (origin: PARENT:encodings)", err)
     assert.falsy(ok)
   end)
 

--- a/spec/12-encoding_spec.lua
+++ b/spec/12-encoding_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local encoding = require "openapi2kong.encoding"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,13 +7,13 @@ describe("[encoding]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = encoding("myProperty", "lalala", nil, {})
-    assert.equal("a encoding object expects a table as spec, but got string", err)
+    assert.equal("a encoding object expects a table as spec, but got string (origin: PARENT:encoding[myProperty])", err)
     assert.falsy(ok)
   end)
 
   it("requires a string parameter as property_name", function()
     local ok, err = encoding(123, {}, nil, {})
-    assert.equal("a encoding object expects a string as property_name, but got number", err)
+    assert.equal("a encoding object expects a string as property_name, but got number (origin: PARENT:encoding[123])", err)
     assert.falsy(ok)
   end)
 
@@ -32,7 +33,7 @@ describe("[encoding]", function()
     local result, err = encoding("myProperty", {
         headers = "lalala",
       }, nil, {})
-    assert.equal("a headers object expects a table, but got string", err)
+    assert.equal("a headers object expects a table, but got string (origin: PARENT:encoding[myProperty]:headers)", err)
     assert.is_nil(result)
   end)
 

--- a/spec/13-headers_spec.lua
+++ b/spec/13-headers_spec.lua
@@ -1,10 +1,11 @@
+_G._TEST = true
 local headers = require "openapi2kong.headers"
 
 describe("[headers]", function()
 
   it("requires a table parameter", function()
     local ok, err = headers("lalala", nil, {})
-    assert.equal("a headers object expects a table, but got string", err)
+    assert.equal("a headers object expects a table, but got string (origin: PARENT:headers)", err)
     assert.falsy(ok)
   end)
 

--- a/spec/14-header_spec.lua
+++ b/spec/14-header_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local header = require "openapi2kong.header"
 
 assert:set_parameter("TableFormatLevel", 5)

--- a/spec/15-requestBody_spec.lua
+++ b/spec/15-requestBody_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local requestBody = require "openapi2kong.requestBody"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,7 +7,7 @@ describe("[requestBody]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = requestBody("lalala", nil, {})
-    assert.equal("a requestBody object expects a table as spec, but got string", err)
+    assert.equal("a requestBody object expects a table as spec, but got string (origin: PARENT:requestBody)", err)
     assert.falsy(ok)
   end)
 
@@ -32,7 +33,7 @@ describe("[requestBody]", function()
           ["text/plain"] = { schema = {} },
         }
       }, nil, {})
-    assert.equal("a mediaType object expects a table as spec, but got string", err)
+    assert.equal("a mediaType object expects a table as spec, but got string (origin: PARENT:requestBody:mediaType[application/json])", err)
     assert.falsy(result)
   end)
 

--- a/spec/16-securityRequirement_spec.lua
+++ b/spec/16-securityRequirement_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local common = require "openapi2kong.common"
 local securityRequirement = require "openapi2kong.securityRequirement"
 
@@ -7,13 +8,13 @@ describe("[securityRequirement]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = securityRequirement("lalala", nil, {})
-    assert.equal("a securityRequirement object expects a table as spec, but got string", err)
+    assert.equal("a securityRequirement object expects a table as spec, but got string (origin: PARENT:securityRequirement)", err)
     assert.falsy(ok)
   end)
 
   it("fails without at leat 1 securityScheme", function()
     local ok, err = securityRequirement({}, nil, {})
-    assert.equal("a securityRequirement requires at least 1 securityScheme", err)
+    assert.equal("a securityRequirement requires at least 1 securityScheme (origin: PARENT:securityRequirement)", err)
     assert.falsy(ok)
   end)
 
@@ -53,10 +54,11 @@ describe("[securityRequirement]", function()
         },
       }
     }, common.create_mt("openapi"))
+    openapi.get_trace = function() return "" end
     local requirements_spec = { nonexistingAuth = {} }
 
     local result, err = securityRequirement(requirements_spec, nil, openapi)
-    assert.equal("securityScheme not found: #/components/securitySchemes/nonexistingAuth", err)
+    assert.equal("securityScheme not found: #/components/securitySchemes/nonexistingAuth (origin: openapi:securityRequirement)", err)
     assert.is_nil(result)
   end)
 
@@ -71,10 +73,11 @@ describe("[securityRequirement]", function()
         },
       }
     }, common.create_mt("openapi"))
+    openapi.get_trace = function() return "" end
     local requirements_spec = { petstoreAuth = {} }
 
     local result, err = securityRequirement(requirements_spec, nil, openapi)
-    assert.equal("a securityScheme object expects a table as spec, but got string", err)
+    assert.equal("a securityScheme object expects a table as spec, but got string (origin: openapi:securityRequirement:securityScheme[petstoreAuth])", err)
     assert.is_nil(result)
   end)
 

--- a/spec/17-securityScheme_spec.lua
+++ b/spec/17-securityScheme_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local securityScheme = require "openapi2kong.securityScheme"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,19 +7,19 @@ describe("[securityScheme]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = securityScheme("petstoreAuth", {}, "lalala", nil, {})
-    assert.equal("a securityScheme object expects a table as spec, but got string", err)
+    assert.equal("a securityScheme object expects a table as spec, but got string (origin: PARENT:securityScheme[petstoreAuth])", err)
     assert.falsy(ok)
   end)
 
   it("requires a string parameter as scheme_name", function()
     local ok, err = securityScheme(123, {}, {}, nil, {})
-    assert.equal("a securityScheme object expects a string as scheme_name, but got number", err)
+    assert.equal("a securityScheme object expects a string as scheme_name, but got number (origin: PARENT:securityScheme[123])", err)
     assert.falsy(ok)
   end)
 
   it("requires a table parameter as scopes", function()
     local ok, err = securityScheme("petstoreAuth", "lalala", {}, nil, {})
-    assert.equal("a securityScheme object expects a table as scopes, but got string", err)
+    assert.equal("a securityScheme object expects a table as scopes, but got string (origin: PARENT:securityScheme[petstoreAuth])", err)
     assert.falsy(ok)
   end)
 
@@ -32,7 +33,7 @@ describe("[securityScheme]", function()
           name = 123,
           ["in"] = "header",
         }, nil, {})
-      assert.equal("a securityScheme object of type apiKey expects a string as name property, but got number", err)
+      assert.equal("a securityScheme object of type apiKey expects a string as name property, but got number (origin: PARENT:securityScheme[petstoreAuth])", err)
       assert.falsy(ok)
     end)
 
@@ -42,7 +43,7 @@ describe("[securityScheme]", function()
           name = "x-my-auth",
           ["in"] = "invalid",
         }, nil, {})
-      assert.equal("a securityScheme object of type apiKey expects a proper in property, but got invalid", err)
+      assert.equal("a securityScheme object of type apiKey expects a proper in property, but got invalid (origin: PARENT:securityScheme[petstoreAuth])", err)
       assert.falsy(ok)
     end)
 
@@ -67,7 +68,7 @@ describe("[securityScheme]", function()
           type = "http",
           scheme = 123,
         }, nil, {})
-      assert.equal("a securityScheme object of type http expects a string as scheme property, but got number", err)
+      assert.equal("a securityScheme object of type http expects a string as scheme property, but got number (origin: PARENT:securityScheme[petstoreAuth])", err)
       assert.falsy(ok)
     end)
 
@@ -91,7 +92,7 @@ describe("[securityScheme]", function()
           type = "oauth2",
           flows = 123,
         }, nil, {})
-      assert.equal("a securityScheme object of type oauth2 expects a table as flows property, but got number", err)
+      assert.equal("a securityScheme object of type oauth2 expects a table as flows property, but got number (origin: PARENT:securityScheme[petstoreAuth])", err)
       assert.falsy(ok)
     end)
 
@@ -100,7 +101,7 @@ describe("[securityScheme]", function()
           type = "oauth2",
           flows = {},
         }, nil, {})
-      assert.equal("a securityScheme object of type oauth2 expects at least 1 entry in the flows property", err)
+      assert.equal("a securityScheme object of type oauth2 expects at least 1 entry in the flows property (origin: PARENT:securityScheme[petstoreAuth])", err)
       assert.falsy(ok)
     end)
 
@@ -131,7 +132,7 @@ describe("[securityScheme]", function()
           type = "openIdConnect",
           openIdConnectUrl = 123,
         }, nil, {})
-      assert.equal("a securityScheme object of type openIdConnect expects a string as openIdConnectUrl property, but got number", err)
+      assert.equal("a securityScheme object of type openIdConnect expects a string as openIdConnectUrl property, but got number (origin: PARENT:securityScheme[petstoreAuth])", err)
       assert.falsy(ok)
     end)
 

--- a/spec/18-oauthFlow_spec.lua
+++ b/spec/18-oauthFlow_spec.lua
@@ -1,3 +1,4 @@
+_G._TEST = true
 local oauthFlow = require "openapi2kong.oauthFlow"
 
 assert:set_parameter("TableFormatLevel", 5)
@@ -6,13 +7,13 @@ describe("[oauthFlow]", function()
 
   it("requires a table parameter as spec", function()
     local ok, err = oauthFlow("implicit", "lalala", nil, {})
-    assert.equal("a oauthFlow object expects a table as spec, but got string", err)
+    assert.equal("a oauthFlow object expects a table as spec, but got string (origin: PARENT:oauthFlow[implicit])", err)
     assert.falsy(ok)
   end)
 
   it("requires a string parameter as flow_type", function()
     local ok, err = oauthFlow(123, {}, nil, {})
-    assert.equal("a oauthFlow object expects a proper flow_type, but got 123", err)
+    assert.equal("a oauthFlow object expects a proper flow_type, but got 123 (origin: PARENT:oauthFlow[123])", err)
     assert.falsy(ok)
   end)
 
@@ -25,7 +26,7 @@ describe("[oauthFlow]", function()
           authorizationUrl = 123,
           scopes = {},
         }, nil, {})
-      assert.equal("a oauthFlow object expects a string as authorizationUrl, but got number", err)
+      assert.equal("a oauthFlow object expects a string as authorizationUrl, but got number (origin: PARENT:oauthFlow[implicit])", err)
       assert.falsy(ok)
     end)
 
@@ -34,7 +35,7 @@ describe("[oauthFlow]", function()
           authorizationUrl = "https://auth.mycompany.com",
           scopes = 123,
         }, nil, {})
-      assert.equal("a oauthFlow object expects a table as scopes, but got number", err)
+      assert.equal("a oauthFlow object expects a table as scopes, but got number (origin: PARENT:oauthFlow[implicit])", err)
       assert.falsy(ok)
     end)
 

--- a/src/openapi2kong/_template.lua
+++ b/src/openapi2kong/_template.lua
@@ -2,6 +2,15 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
+function mt:get_trace()
+  -- Each object must implement `get_trace` to return the named element of the
+  -- object. It can return an empty string for generic collections, but should
+  -- return the human identifiable id where possible.
+  -- eg. for `paths` return ""
+  --     for `paths["/some/path"]` return "/some/path"
+  print("TODO: implement ", TYPE_NAME)
+end
+
 
 function mt:validate()
 
@@ -33,7 +42,7 @@ print("TODO: implement ", TYPE_NAME)
   do
     local ok, err = self:dereference()
     if not ok then
-      return ok, err
+      return ok, self:log_message(err)
     end
     -- prevent accidental access to non-dereferenced spec table
     spec = nil -- luacheck: ignore
@@ -41,7 +50,7 @@ print("TODO: implement ", TYPE_NAME)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   for _, property in ipairs { "servers", "paths" } do
@@ -59,7 +68,7 @@ print("TODO: implement ", TYPE_NAME)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/encoding.lua
+++ b/src/openapi2kong/encoding.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return self.property_name
+end
+
+
 function mt:validate()
 
   if type(self.property_name) ~= "string" then
@@ -36,7 +41,7 @@ local function parse(property_name, spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   for _, property in ipairs { "headers" } do
@@ -54,7 +59,7 @@ local function parse(property_name, spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/encodings.lua
+++ b/src/openapi2kong/encodings.lua
@@ -6,6 +6,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -24,7 +29,7 @@ function mt:post_validate()
 end
 
 
--- returns an array with path entries
+-- returns an array with encoding entries
 local function parse(spec, options, parent)
 
   local self = setmetatable({
@@ -35,7 +40,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   self.encodings = {}
@@ -49,7 +54,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/header.lua
+++ b/src/openapi2kong/header.lua
@@ -42,7 +42,7 @@ local function parse(name, spec, options, parent)
   do
     local ok, err = temp_header:dereference()
     if not ok then
-      return ok, err
+      return ok, temp_header:log_message(err)
     end
     -- prevent accidental access to non-dereferenced spec table
     spec = nil -- luacheck: ignore

--- a/src/openapi2kong/headers.lua
+++ b/src/openapi2kong/headers.lua
@@ -6,6 +6,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -35,7 +40,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   self.headers = {}
@@ -51,7 +56,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/init.lua
+++ b/src/openapi2kong/init.lua
@@ -452,24 +452,24 @@ local function convert_paths(openapi, options)
       do -- check security plugins required
         local requirements, err = operation_obj:get_security()
         if (not requirements) and err ~= "not found" then
-          return nil, err
+          return nil, operation_obj:log_message(err)
         end
 
         if requirements and #requirements > 0 then
           if #requirements > 1 then
-            return nil, "maximum of 1 Security Requirement supported, got " .. #requirements
+            return nil, operation_obj:log_message("maximum of 1 Security Requirement supported, got " .. #requirements)
           end
 
           local security_requirement = requirements[1]
           if #security_requirement > 1 then
-            return nil, "maximum of 1 Security Scheme supported, got " .. #security_requirement
+            return nil, operation_obj:log_message("maximum of 1 Security Scheme supported, got " .. #security_requirement)
           end
 
           local plugin_conf = registry_get(requirements)
           if not plugin_conf then
             plugin_conf, err = create_security_plugin(security_requirement[1])
             if not plugin_conf then
-              return nil, err
+              return nil, operation_obj:log_message(err)
             end
 
             registry_add(requirements, plugin_conf)
@@ -498,7 +498,7 @@ local function convert_paths(openapi, options)
           local err
           request_validator_config.config, err = generate_validation_config(operation_obj)
           if not request_validator_config.config then
-            return nil, err
+            return nil, operation_obj:log_message(err)
           end
 
           -- anything to validate?

--- a/src/openapi2kong/mediaType.lua
+++ b/src/openapi2kong/mediaType.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return self.mediatype
+end
+
+
 function mt:validate()
 
   if type(self.mediatype) ~= "string" then
@@ -36,7 +41,7 @@ local function parse(mediatype, spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   if self.spec.schema then
@@ -57,7 +62,7 @@ local function parse(mediatype, spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/oauthFlow.lua
+++ b/src/openapi2kong/oauthFlow.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return self.flow_type
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -68,7 +73,7 @@ local function parse(flow_type, spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
 
@@ -76,7 +81,7 @@ local function parse(flow_type, spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/openapi.lua
+++ b/src/openapi2kong/openapi.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return (self.spec.info or {}).title or ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -119,7 +124,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   for _, property in ipairs { "servers", "paths" } do
@@ -146,7 +151,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/operation.lua
+++ b/src/openapi2kong/operation.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return self.method
+end
+
+
 function mt:validate()
 
   if type(self.method) ~= "string" then
@@ -41,7 +46,7 @@ local function parse(method, spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   for _, property in ipairs { "parameters", "requestBody", "servers" } do
@@ -67,7 +72,7 @@ local function parse(method, spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/parameters.lua
+++ b/src/openapi2kong/parameters.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -72,7 +77,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   local new_parameter = require "openapi2kong.parameter"
@@ -90,7 +95,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/path.lua
+++ b/src/openapi2kong/path.lua
@@ -7,6 +7,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return self.path
+end
+
+
 function mt:validate()
 
   if type(self.path) ~= "string" then
@@ -43,7 +48,7 @@ local function parse(path, spec, options, parent)
   do
     local ok, err = self:dereference()
     if not ok then
-      return ok, err
+      return ok, self:log_message(err)
     end
     -- prevent accidental access to non-dereferenced spec table
     spec = nil -- luacheck: ignore
@@ -51,7 +56,7 @@ local function parse(path, spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   for _, property in ipairs { "servers", "parameters" } do
@@ -91,7 +96,7 @@ local function parse(path, spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/paths.lua
+++ b/src/openapi2kong/paths.lua
@@ -6,6 +6,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -35,7 +40,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   --self.paths = {}
@@ -50,7 +55,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/requestBody.lua
+++ b/src/openapi2kong/requestBody.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -33,7 +38,7 @@ local function parse(spec, options, parent)
   do
     local ok, err = self:dereference()
     if not ok then
-      return ok, err
+      return ok, self:log_message(err)
     end
     -- prevent accidental access to non-dereferenced spec table
     spec = nil -- luacheck: ignore
@@ -41,7 +46,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   if self.spec.content then
@@ -59,7 +64,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/schema.lua
+++ b/src/openapi2kong/schema.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -32,7 +37,7 @@ local function parse(spec, options, parent)
   do
     local ok, err = self:dereference()
     if not ok then
-      return ok, err
+      return ok, self:log_message(err)
     end
     -- prevent accidental access to non-dereferenced spec table
     spec = nil -- luacheck: ignore
@@ -40,12 +45,12 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/securityRequirement.lua
+++ b/src/openapi2kong/securityRequirement.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -36,7 +41,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   local new_securityScheme = require("openapi2kong.securityScheme")
@@ -44,7 +49,7 @@ local function parse(spec, options, parent)
   for scheme_name, scopes_spec in pairs(self.spec) do
     local scheme_spec = ((self:get_openapi().spec.components or {}).securitySchemes or {})[scheme_name]
     if not scheme_spec then
-      return nil, "securityScheme not found: #/components/securitySchemes/" .. scheme_name
+      return nil, self:log_message("securityScheme not found: #/components/securitySchemes/" .. scheme_name)
     end
 
     local scheme_obj, err = new_securityScheme(scheme_name, scopes_spec, scheme_spec, options, self)
@@ -57,7 +62,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/securityRequirements.lua
+++ b/src/openapi2kong/securityRequirements.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -31,7 +36,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   local new_securityRequirement = require("openapi2kong.securityRequirement")
@@ -45,7 +50,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/securityScheme.lua
+++ b/src/openapi2kong/securityScheme.lua
@@ -3,6 +3,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return self.scheme_name
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -80,7 +85,7 @@ local function parse(scheme_name, scopes, spec, options, parent)
   do
     local ok, err = self:dereference()
     if not ok then
-      return ok, err
+      return ok, self:log_message(err)
     end
     -- prevent accidental access to non-dereferenced spec table
     spec = nil -- luacheck: ignore
@@ -88,7 +93,7 @@ local function parse(scheme_name, scopes, spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   if self.spec.type == "oauth2" then
@@ -106,7 +111,7 @@ local function parse(scheme_name, scopes, spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self

--- a/src/openapi2kong/servers.lua
+++ b/src/openapi2kong/servers.lua
@@ -5,6 +5,11 @@ local TYPE_NAME = ({...})[1]:match("openapi2kong%.([^%.]+)$")  -- grab type-name
 local mt = require("openapi2kong.common").create_mt(TYPE_NAME)
 
 
+function mt:get_trace()
+  return ""
+end
+
+
 function mt:validate()
 
   if type(self.spec) ~= "table" then
@@ -59,7 +64,7 @@ local function parse(spec, options, parent)
 
   local ok, err = self:validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   for i, server in ipairs(spec) do
@@ -72,7 +77,7 @@ local function parse(spec, options, parent)
 
   ok, err = self:post_validate()
   if not ok then
-    return ok, err
+    return ok, self:log_message(err)
   end
 
   return self


### PR DESCRIPTION
The trace will neable users to identify which element of the input
document generated the error.

Fixes #2 
