### PR TITLE
fix(registry) values should not be weak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog
+
+## 0.2.x xx-Jan-2020
+
+- fix: a weak table caused premature garbage collection of entries still
+  required
 
 ## 0.2.0 22-Nov-2019
 

--- a/src/openapi2kong/init.lua
+++ b/src/openapi2kong/init.lua
@@ -71,7 +71,7 @@ end
 
 local registry_add, registry_get
 do
-  local registry = setmetatable({}, { __mode = "kv" })
+  local registry = setmetatable({}, { __mode = "k" })
 
   --- Add an entry to the generation registry.
   -- The registry keeps track of what Kong entities were generated from OpenAPI


### PR DESCRIPTION
both keys and values in the registry of already generated Kong
objects were weak. This works for single value entities, but
the `servers` entity has two values. So in that case an
intermediate table is created, but that intermediate table is
not anchored anywhere (only the key, and the two entries inside
the table are anchored). Hence in some cases the garbage collector
kicked in and removed the intermediate entry prematurely.

This caused a 'nil'-reference in a later pass requesting the same
entry from the registry.